### PR TITLE
Fix: pushing roll reduces ammo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 <br/>and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 <br/>See also: [The Angular Convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines).
 
+## [10.2.1] - 2023-06-xx
+
+<h4>Bug Fixes</h4><ul><li>Fixed a bug introduced with the previous update that caused weapons pushed rolls with no ammo dice to consume 1 additional ammo.</li></ul>
+
 ## [10.2.0] - 2023-04-20
 
 ### What's Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "cross-env": "7.0.3",
         "devmoji": "2.3.0",
         "esbuild": "^0.15.18",
-        "eslint": "^8.38.0",
+        "eslint": "^8.42.0",
         "eslint-config-jquery": "^3.0.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^4.2.1",
@@ -32,9 +32,9 @@
         "gulp-yaml": "2.0.4",
         "husky": "^8.0.3",
         "less": "^4.1.3",
-        "prettier": "^2.8.7",
+        "prettier": "^2.8.8",
         "prettier-eslint-cli": "^7.1.0",
-        "semver": "^7.5.0",
+        "semver": "^7.5.2",
         "standard-version": "^9.3.2"
       }
     },
@@ -174,14 +174,14 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.2.tgz",
-      "integrity": "sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
+      "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.5.1",
+        "espree": "^9.5.2",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -197,18 +197,18 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.38.0.tgz",
-      "integrity": "sha512-IoD2MfUnOV58ghIHCiil01PcohxjbYR/qCxsoC+xNgUwh1EY8jOOrYmu3d3a71+tJJ23uscEV4X2HJWMsPJu4g==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.42.0.tgz",
+      "integrity": "sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
-      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -5059,16 +5059,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.38.0.tgz",
-      "integrity": "sha512-pIdsD2jwlUGf/U38Jv97t8lq6HpaU/G9NKbYmpWpZGw3LdTNhZLbJePqxOXGB5+JEKfOPU/XLxYxFh03nr1KTg==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.42.0.tgz",
+      "integrity": "sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.0.2",
-        "@eslint/js": "8.38.0",
-        "@humanwhocodes/config-array": "^0.11.8",
+        "@eslint/eslintrc": "^2.0.3",
+        "@eslint/js": "8.42.0",
+        "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
@@ -5077,9 +5077,9 @@
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.1",
-        "eslint-visitor-keys": "^3.4.0",
-        "espree": "^9.5.1",
+        "eslint-scope": "^7.2.0",
+        "eslint-visitor-keys": "^3.4.1",
+        "espree": "^9.5.2",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -5087,13 +5087,12 @@
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
         "globals": "^13.19.0",
-        "grapheme-splitter": "^1.0.4",
+        "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
-        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -5171,9 +5170,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
-      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -5232,14 +5231,14 @@
       "dev": true
     },
     "node_modules/espree": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
-      "integrity": "sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
+      "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.0"
+        "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6442,10 +6441,10 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
-    "node_modules/grapheme-splitter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
     "node_modules/gulp": {
@@ -7233,16 +7232,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/js-sdsl": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
-      "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/js-tokens": {
@@ -9234,9 +9223,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
-      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -10332,9 +10321,9 @@
       "optional": true
     },
     "node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "t2k4e",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "t2k4e",
-      "version": "10.2.0",
+      "version": "10.2.1",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "t2k4e",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "description": "A Foundry VTT system for Twilight 2000 4E (Free League Publishing)",
   "type": "module",
   "author": "Stefouch",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "cross-env": "7.0.3",
     "devmoji": "2.3.0",
     "esbuild": "^0.15.18",
-    "eslint": "^8.38.0",
+    "eslint": "^8.42.0",
     "eslint-config-jquery": "^3.0.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",
@@ -69,9 +69,9 @@
     "gulp-yaml": "2.0.4",
     "husky": "^8.0.3",
     "less": "^4.1.3",
-    "prettier": "^2.8.7",
+    "prettier": "^2.8.8",
     "prettier-eslint-cli": "^7.1.0",
-    "semver": "^7.5.0",
+    "semver": "^7.5.2",
     "standard-version": "^9.3.2"
   }
 }

--- a/src/components/roll/dice.js
+++ b/src/components/roll/dice.js
@@ -215,7 +215,7 @@ export async function rollPush(roll, { message } = {}) {
   // Gets all the message's flags.
   const flags = message.getFlag('t2k4e', 'data') ?? {};
   const oldAmmoSpent = flags.ammoSpent || 0;
-  let newAmmoSpent = -Math.max(1, roll.ammoSpent) - 1;
+  let newAmmoSpent = -Math.max(1, roll.ammoSpent + 1);
   const actorId = roll.options.actorId;
   const tokenKey = roll.options.tokenKey;
   const actor = getRollingActor({ actorId, tokenKey });

--- a/src/less/module-t2k4e-coreset.less
+++ b/src/less/module-t2k4e-coreset.less
@@ -210,6 +210,7 @@ li.directory-item.entity {
 
     .t2k-title-img {
       margin: 2em 0 0 0;
+      text-transform: uppercase;
     }
 
     .t2k-img-description,

--- a/static/assets/messages/messages.jsonc
+++ b/static/assets/messages/messages.jsonc
@@ -38,5 +38,15 @@
     "display": "once", // Time until it goes away: [once, infinite, mm.dd.yyyy]
     "title": "10.2.0 Release Notes",
     "content": "<h4>What's New?</h4><ul><li>Added rules changes from the Augustus 4th, 2022 revision.</li><li>Apply damage (in a roll message's context menu) now uses targeted tokens instead of selected ones.</li><li>Added text enrichers for T2K symbols in journal entries.</li><li>Added a new property <code>system.drawSize</code> for Actors and for increased compatibility with the <a href=\"https://foundryvtt.com/packages/yze-combat\">Year Zero Engine: Combat</a> module.</li><li>Prepared the game system for the release of <i>Urban Operations</i>.</li></ul><h4>Bug Fixes</h4><ul><li>NPC stress bar is now correctly hidden by default for tokens.</li><li>Fixed a bug where the equip and backpack icons in the inventory for ammunitions were not working.</li><li>Fixed a bug where a single die was not modified properly.</li></ul>"
+  },
+  {
+    // "min-core-version": "9.0.0", //optional, inclusive
+    // "max-core-version": "10.0.0", //optional, exclusive
+    "min-sys-version": "10.2.1", //optional, inclusive
+    "max-sys-version": "10.2.2", //optional, exclusive
+    "type": "prompt", // Type of message: [prompt, chat]
+    "display": "once", // Time until it goes away: [once, infinite, mm.dd.yyyy]
+    "title": "10.2.1 Release Notes",
+    "content": "<h4>Bug Fixes</h4><ul><li>Fixed a bug introduced with the previous update that caused weapons pushed rolls with no ammo dice to consume 1 additional ammo.</li></ul>"
   }
 ]

--- a/static/system.json
+++ b/static/system.json
@@ -2,7 +2,7 @@
   "id": "t2k4e",
   "title": "Twilight: 2000 🪖 (4th Edition)",
   "description": "Twilight: 2000 is a roleplaying game about survival in mankind’s most desperate hour. Yet, in this bleak world, there is still hope. In the midst of utter destruction, you can start to build something new. Rally people to your ranks. Stake a claim and protect it. And maybe, if you live long enough, start turning the tide.",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "compatibility": {
     "minimum": 10,
     "verified": "10.291",
@@ -58,6 +58,6 @@
   "initiative": "1d10",
   "url": "https://github.com/fvtt-fria-ligan/twilight2000-foundry-vtt",
   "manifest": "https://github.com/fvtt-fria-ligan/twilight2000-foundry-vtt/releases/latest/download/system.json",
-  "download": "https://github.com/fvtt-fria-ligan/twilight2000-foundry-vtt/releases/download/10.2.0/t2k4e-fvtt_v10.2.0.zip",
+  "download": "https://github.com/fvtt-fria-ligan/twilight2000-foundry-vtt/releases/download/10.2.1/t2k4e-fvtt_v10.2.1.zip",
   "license": "GPL-3.0-or-later"
 }


### PR DESCRIPTION
## Summary
<!-- Here goes a short summary about what the PR is about. -->

<ul><li>Fixed a bug introduced with the previous update that caused weapons pushed rolls with no ammo dice to consume 1 additional ammo.</li></ul>

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->
### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes (wiki).